### PR TITLE
fix: malformed json, if keys are just partially mentioned in .Order array

### DIFF
--- a/jsonmap.go
+++ b/jsonmap.go
@@ -100,7 +100,7 @@ func (o Ordered) MarshalJSON() ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			if start {
+			if !start {
 				buf.WriteByte(',')
 				start = false
 			}

--- a/jsonmap_test.go
+++ b/jsonmap_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/dolmen-go/jsonmap"
 )
 
-func TestOrdered(t *testing.T) {
+func TestWithoutOrder(t *testing.T) {
 	orig := []byte(`{
 		"name": "John",
 		"age": 20
@@ -38,6 +38,30 @@ func TestOrdered(t *testing.T) {
 	t.Logf("%s", out)
 
 	m.Order = nil
+	out, err = json.Marshal(&m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%s", out)
+}
+
+func TestWithOrder_Partially(t *testing.T) {
+	orig := []byte(`{
+		"name": "John",
+		"age": 20
+	  }`)
+
+	var m jsonmap.Ordered
+	if err := json.Unmarshal(orig, &m); err != nil {
+		t.Fatal(err)
+	}
+	out, err := json.Marshal(&m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%s", out)
+
+	m.Order = []string{"age"}
 	out, err = json.Marshal(&m)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
If the .Order array only contains part of the maps keys, the MarshalJSON method produced invalid JSON. I also added a test to confirm that this case now is covered.

> --- FAIL: TestWithOrder_Partially (0.00s)
>     f:\repos\jsonmap\jsonmap_test.go:62: {"name":"John","age":20}
>     f:\repos\jsonmap\jsonmap_test.go:67: json: error calling MarshalJSON for type *jsonmap.Ordered: invalid character '"' after object key:value pair
> FAIL
> FAIL	github.com/dolmen-go/jsonmap	0.955s
> FAIL